### PR TITLE
✨ (action.yaml): add read_checksum_token input to allow custom token for aqua update-checksum

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -9,6 +9,13 @@ inputs:
   skip_push:
     required: false
     default: false
+  read_checksum_token:
+    required: false
+    default: ''  # empty string replaced by `env.GITHUB_TOKEN`
+    description: |
+      This token to be used when executes `aqua update-checksum`. It must have `contents:read` permission about all repositories
+      in tools managed by `aqua`. By default, `env.GITHUB_TOKEN` is used.
+      This input is useful to fetch checksum from private repositories.
 runs:
   using: composite
   steps:
@@ -16,10 +23,14 @@ runs:
       working-directory: ${{inputs.working_directory}}
       run: aqua update-checksum -deep
       if: inputs.prune != 'true'
+      env:
+        GITHUB_TOKEN: ${{ (inputs.read_checksum_token != '') &&  inputs.read_checksum_token || env.GITHUB_TOKEN }}
     - shell: bash
       working-directory: ${{inputs.working_directory}}
       run: aqua update-checksum -deep -prune
       if: inputs.prune == 'true'
+      env:
+        GITHUB_TOKEN: ${{ (inputs.read_checksum_token != '') &&  inputs.read_checksum_token || env.GITHUB_TOKEN }}
 
     - shell: bash
       id: find

--- a/action.yaml
+++ b/action.yaml
@@ -11,11 +11,10 @@ inputs:
     default: false
   read_checksum_token:
     required: false
-    default: ''  # empty string replaced by `env.GITHUB_TOKEN`
+    default: ''  # When this input is an empty string, it doesn't override `AQUA_GITHUB_TOKEN`.
     description: |
-      This token to be used when executes `aqua update-checksum`. It must have `contents:read` permission about all repositories
-      in tools managed by `aqua`. By default, `env.GITHUB_TOKEN` is used.
-      This input is useful to fetch checksum from private repositories.
+      This token overrides `AQUA_GITHUB_TOKEN` to executes `aqua update-checksum`. It must have `contents:read` permission about all repositories
+      in tools managed by `aqua`. This input is useful to fetch checksum from private repositories.
 runs:
   using: composite
   steps:
@@ -24,13 +23,13 @@ runs:
       run: aqua update-checksum -deep
       if: inputs.prune != 'true'
       env:
-        GITHUB_TOKEN: ${{ (inputs.read_checksum_token != '') &&  inputs.read_checksum_token || env.GITHUB_TOKEN }}
+        AQUA_GITHUB_TOKEN: ${{ (inputs.read_checksum_token != '') &&  inputs.read_checksum_token || env.AQUA_GITHUB_TOKEN }}
     - shell: bash
       working-directory: ${{inputs.working_directory}}
       run: aqua update-checksum -deep -prune
       if: inputs.prune == 'true'
       env:
-        GITHUB_TOKEN: ${{ (inputs.read_checksum_token != '') &&  inputs.read_checksum_token || env.GITHUB_TOKEN }}
+        AQUA_GITHUB_TOKEN: ${{ (inputs.read_checksum_token != '') &&  inputs.read_checksum_token || env.AQUA_GITHUB_TOKEN }}
 
     - shell: bash
       id: find


### PR DESCRIPTION
If I want to manage tools in private repositories with aqua, it requires to change dedicated GitHub token only when `aqua update-checksum`. I changed to be able to pass a token for that with `input`.