### PR TITLE
chore: Replace int128/ghcp by suzuki-shunsuke/ghcp

### DIFF
--- a/aqua-checksums.json
+++ b/aqua-checksums.json
@@ -1,28 +1,33 @@
 {
   "checksums": [
     {
-      "id": "github_release/github.com/int128/ghcp/v1.13.5/ghcp_darwin_amd64.zip",
-      "checksum": "6728BD668888A64C71BF01D9AFBA373F38D353B79D181B1401A4E5E4B329289D",
+      "id": "github_release/github.com/suzuki-shunsuke/ghcp/v1.16.0/ghcp_darwin_amd64.tar.gz",
+      "checksum": "CA5EB65ED4469148B539AA4B83E1FB77887FAC3C36896DF8E5CC8702E7488B1A",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/int128/ghcp/v1.13.5/ghcp_darwin_arm64.zip",
-      "checksum": "6533FA0396CA6F4B9D3A74C2F0A5C4C89575A0D79F90684BAF6CD8B1511C95AC",
+      "id": "github_release/github.com/suzuki-shunsuke/ghcp/v1.16.0/ghcp_darwin_arm64.tar.gz",
+      "checksum": "56B0ED7135FEB44A2A7EC6A8960CA1E4C15D64B45A4ECDB307FC91A4EBBF33AC",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/int128/ghcp/v1.13.5/ghcp_linux_amd64.zip",
-      "checksum": "3C808E566F0B663182AD5B5DD6E6B05DC8346610EA5613EA8C22AB19F47A4493",
+      "id": "github_release/github.com/suzuki-shunsuke/ghcp/v1.16.0/ghcp_linux_amd64.tar.gz",
+      "checksum": "89D99FA73477C11A60B274E385B9E990125D411C73F971D4CF21069BF7DB92C6",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/int128/ghcp/v1.13.5/ghcp_linux_arm64.zip",
-      "checksum": "14068BF35B2ED187EE7D8DB854DF2E7913C2BBC981979D3F8AE533D058E35F16",
+      "id": "github_release/github.com/suzuki-shunsuke/ghcp/v1.16.0/ghcp_linux_arm64.tar.gz",
+      "checksum": "7DE544BF3CD3FA2830671F078484F0AA2C9C8BEC8D7E887835250E77A62CC775",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/int128/ghcp/v1.13.5/ghcp_windows_amd64.zip",
-      "checksum": "1A90AD7927F720EB8996AE143DF5D7AA2DF70689B7B5B9074D6FD32C244D688E",
+      "id": "github_release/github.com/suzuki-shunsuke/ghcp/v1.16.0/ghcp_windows_amd64.zip",
+      "checksum": "96A93551D3FA3760A85B0128EE0BC48B8913041022A2F59DA1FD8FE3D9DFA1C5",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/ghcp/v1.16.0/ghcp_windows_arm64.zip",
+      "checksum": "07BA508B368F50266E06CED36135F2A68D4816CDC38D739AA7E7D50E0CBFC265",
       "algorithm": "sha256"
     },
     {

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -10,4 +10,4 @@ registries:
   - type: standard
     ref: v4.349.0 # renovate: depName=aquaproj/aqua-registry
 packages:
-  - name: int128/ghcp@v1.13.5
+  - name: suzuki-shunsuke/ghcp@v1.16.0


### PR DESCRIPTION
## What

Replace int128/ghcp by suzuki-shunsuke/ghcp.

## Why

int128/ghcp isn't compiled CGO_ENABLED=0.
So, it causes GLIB issues sometimes.

```console
ghcp: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by ghcp)
ghcp: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by ghcp)
```

It should be better to use CGO_ENABLED=0 version.